### PR TITLE
"options" parameter support for multicheck, multicheck_inline, radio, radio_inline and select field types

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,3 +61,30 @@ form {
 #codecontainer{
     display: none;
 }
+
+.opt-key, .opt-val, .opt-param-type, .opt-callback {
+    margin-top: 3px;
+}
+
+.option-param .btn-warning,
+.opt-add, .opt-remove {
+    margin-top: 10px;
+}
+
+.form-element .option-param .opt-add {
+    display: none;
+}
+
+.form-element .option-param:last-child .opt-add {
+    display: inline-block;
+}
+
+.form-element .option-param h4,
+.form-element .option-param .opt-param-type {
+    display: none;
+}
+
+.form-element .option-param:nth-child(2) h4,
+.form-element .option-param:nth-child(2) .opt-param-type {
+    display: block;
+}

--- a/index.html
+++ b/index.html
@@ -203,6 +203,38 @@
 
 </div>
 
+<!-- HTML element for option params when we select multicheck, multicheck_inline, radio, radio_inline and select field types  -->
+<div class="hidden" id="option-param-elem">
+    <div class="row option-param">
+        <div class="col-md-3">
+            <h4 class="text-right">options</h4>
+        </div>
+        <div class="col-md-2">
+            <select class="form-control opt-param-type">
+                <option value="array" selected>Array</option>
+                <option value="callback">Callback</option>
+            </select>
+        </div>
+        <div class="col-md-1 text-center" data-opt-type="array">
+            <a href="#move-up" class="btn btn-warning btn-xs opt-move-up" title="Move Up"><i class="glyphicon glyphicon-arrow-up"></i></a>
+            <a href="#move-down" class="btn btn-warning btn-xs opt-move-down" title="Move Down"><i class="glyphicon glyphicon-arrow-down"></i></a>
+        </div>
+        <div class="col-md-2" data-opt-type="array">
+            <input type="text" class="form-control opt-key" placeholder="key">
+        </div>
+        <div class="col-md-2" data-opt-type="array">
+            <input type="text" class="form-control opt-val" placeholder="value">
+        </div>
+        <div class="col-md-5 hidden" data-opt-type="callback">
+            <input type="text" class="form-control opt-callback" placeholder="callback function name">
+        </div>
+        <div class="col-md-2" data-opt-type="array">
+            <a class="btn btn-success btn-xs opt-add" href="#add-more" title="Add more">+</a>
+            <a class="btn btn-danger btn-xs opt-remove" href="#remove-this" title="Remove this">×</a>
+        </div>
+    </div>
+</div><!-- #option-param-elem -->
+
 <div class="section footer">
     <p>Built with Love by Hasin Hayder</p>
 </div>

--- a/js/script.js
+++ b/js/script.js
@@ -10,7 +10,7 @@
         $('#fields').on('click', '.add-more', function (e) {
             dirty = 1;
             e.preventDefault();
-            $(this).parents(".form-element").clone().appendTo("#fields");
+            $(this).parents(".form-element").clone().appendTo("#fields").find('.option-param').remove();
             $(this).hide();
         });
 
@@ -68,6 +68,30 @@
                 item.def = $(this).find(".mb_field_default").val();
                 item.textdomain = elements.mb_textdomain;
 
+                // option param
+                if ($(this).has('.option-param').length) {
+                    item.has_option = true;
+
+                    var options = $(this).children('.option-param');
+
+                    item.option_type = options.first().find('.opt-param-type').val();
+
+                    if ('callback' === item.option_type) {
+                        item.option_cb = options.first().find('.opt-callback').val();
+                    } else {
+                        item.options = {};
+
+                        options.each(function (i) {
+                            item.options[i] = {
+                                key: $(this).find('.opt-key').val(),
+                                value: $(this).find('.opt-val').val(),
+                                textdomain: elements.mb_textdomain
+                            }
+                        });
+                    }
+
+                }
+
                 elements.elements.push(item);
             });
 
@@ -82,22 +106,31 @@
         });
 
         function generateCode(elements) {
+            var option_arr_elem = "                       \"<%= key %>\" => __( \"<%= value %>\", \"<%= textdomain %>\" ),\n";
+
+            var option_arr = "                    \"options\"   => array(\n" +
+                "<%= option_elems %>" +
+                "                     ),\n";
+
+            var option_cb = "                    \"options\"   => \"<%= option_cb %>\"";
+
             var field = "			array(\n" +
                 "					\"name\"    => __( '<%= title %>', '<%= textdomain %>' ),\n" +
                 "					\"id\"      =>  \"<%= id %>\",\n" +
                 "					\"type\"    => \"<%= type %>\",\n" +
                 "					\"default\"    => \"<%= def %>\",\n" +
-                "				),\n" ;
+                "<%= option_param %>         \n" +
+                "               ),\n" ;
             var metabox = "add_filter( 'cmb2_meta_boxes', '<%= mb_function %>' );\n" +
                 "function <%= mb_function %>( array $meta_boxes ) {\n" +
-                "	$meta_boxes['<%= mb_id %>'] = array(\n" +
-                "		'id'           => '<%= mb_id %>',\n" +
-                "		'title'        => __( '<%= mb_title %>', '<%= mb_textdomain %>' ),\n" +
-                "		'object_types' => array( <%= mb_scope %> ), // Post type\n" +
-                "		'context'      => '<%= mb_context %>',\n" +
-                "		'priority'     => '<%= mb_priority %>',\n" +
-                "		'show_names'   => true,\n" +
-                "		'fields'       => array(\n" +
+                "   $meta_boxes['<%= mb_id %>'] = array(\n" +
+                "       'id'           => '<%= mb_id %>',\n" +
+                "       'title'        => __( '<%= mb_title %>', '<%= mb_textdomain %>' ),\n" +
+                "       'object_types' => array( <%= mb_scope %> ), // Post type\n" +
+                "       'context'      => '<%= mb_context %>',\n" +
+                "       'priority'     => '<%= mb_priority %>',\n" +
+                "       'show_names'   => true,\n" +
+                "       'fields'       => array(\n" +
                 "<%= fields %>         \n" +
                 "		)\n" +
                 "	);\n" +
@@ -110,6 +143,25 @@
             var fields = "";
             for(i in elements.elements){
                 var element = elements.elements[i];
+
+                if (element.has_option && 'array' === element.option_type) {
+                    element.option_elems = "";
+                    for(j in element.options) {
+                        var opt_elem_tmplt = _.template(option_arr_elem);
+
+                        element.option_elems += opt_elem_tmplt(element.options[j]);
+                    }
+
+                    var optionTemplate = _.template(option_arr);
+                    element.option_param = optionTemplate(element);
+
+                } else if (element.has_option) {
+                    var optionTemplate = _.template(option_cb);
+                    element.option_param = optionTemplate(element);
+                } else {
+                    element.option_param = "";
+                }
+
                 fields += fieldTemplate(element);
             }
 
@@ -119,5 +171,75 @@
             Prism.highlightAll();
             $("#codecontainer").show();
         }
+
+        // option param for multicheck, multicheck_inline, radio, radio_inline and select field types
+        $('#fields').on('change', '.mb_field_type', function () {
+            var dropdown = $(this),
+                selected_option = dropdown.val(),
+                form_elem = dropdown.parents('.form-element'),
+                html_element = $('#option-param-elem').children(),
+                field_types = ['multicheck', 'multicheck_inline', 'radio', 'radio_inline', 'select'],
+                position_in_array = $.inArray(selected_option, field_types),
+                has_option_elem = form_elem.has('.option-param').length;
+
+            if (position_in_array >= 0 && !has_option_elem) {
+                html_element.clone().appendTo(form_elem);
+            } else if (position_in_array < 0 && has_option_elem) {
+                form_elem.find('.option-param').remove();
+            }
+
+        });
+
+        // option param type: array or callback function
+        $('#fields').on('change', '.opt-param-type', function () {
+            var dropdown = $(this),
+                type = dropdown.val(),
+                form_elem = dropdown.parents('.form-element');
+
+            form_elem.children('.option-param').not(':first').remove().end()
+                     .find('[data-opt-type]').addClass('hidden').end()
+                     .find('[data-opt-type="' + type + '"]').removeClass('hidden');
+        });
+
+        // option param element move up
+        $('#fields').on('click', '.opt-move-up', function (e) {
+            e.preventDefault();
+
+            var current = $(this).parents('.option-param'),
+                prev_elem = current.prev('.option-param');
+
+            if (prev_elem.length) {
+                prev_elem.before(current);
+            }
+        });
+
+        // option param element move down
+        $('#fields').on('click', '.opt-move-down', function (e) {
+            e.preventDefault();
+
+            var current = $(this).parents('.option-param'),
+                next_elem = current.next('.option-param');
+
+            if (next_elem.length) {
+                next_elem.after(current);
+            }
+        });
+
+
+        // add another option param when click .opt-add button
+        $('#fields').on('click', '.opt-add', function (e) {
+            e.preventDefault();
+            $('#option-param-elem').children().clone()
+                .appendTo($(this).parents('.form-element'));
+        });
+
+        // remove an option param when click .opt-remove button
+        $('#fields').on('click', '.opt-remove', function (e) {
+            e.preventDefault();
+
+            if (confirm("Are you sure to delete?")) {
+                $(this).parents('.option-param').remove();
+            }
+        });
     });
 })(jQuery);


### PR DESCRIPTION
Example: https://github.com/WebDevStudios/CMB2/wiki/Field-Types#radio

Works only for multicheck, multicheck_inline, radio, radio_inline and select field types. When you select one of these field types, you'll get options to add your array key/value pair or simply the callback function.

![screenshot from 2015-06-14 23 56 16](https://cloud.githubusercontent.com/assets/1541774/8149746/fb4825a2-12f0-11e5-90d5-f85fea2e99af.png)
